### PR TITLE
Updated API, email via toolbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Comment 0.8.18
+# Comment 0.8.19
 
 Simple commenting system.
 

--- a/comment.php
+++ b/comment.php
@@ -2,7 +2,7 @@
 // Comment extension, https://github.com/GiovanniSalmeri/yellow-comment
 
 class YellowComment {
-    const VERSION = "0.8.18";
+    const VERSION = "0.8.19";
     public $yellow;         //access to API
 
     var $comment;
@@ -369,13 +369,16 @@ class YellowComment {
         } else {
             $mailMessage.= "Remove: " . $this->yellow->page->getUrl() . "?aid=" . $comment["meta"]["aid"] . "&action=remove\r\n";
         }
-        $mailSubject = mb_encode_mimeheader("[".$this->yellow->system->get("sitename")."] " . $this->yellow->page->get("title"));
-        $mailHeaders = "From: " . mb_encode_mimeheader($comment["meta"]["name"]) . " <" . $comment["meta"]["from"] . ">\r\n";
-        $mailHeaders .= "X-Contact-Url: " . mb_encode_mimeheader($this->yellow->page->getUrl()) . "\r\n";
-        $mailHeaders .= "X-Remote-Addr: " . mb_encode_mimeheader($this->yellow->toolbox->getServer("REMOTE_ADDR")) . "\r\n";
-        $mailHeaders .= "Mime-Version: 1.0\r\n";
-        $mailHeaders .= "Content-Type: text/plain; charset=utf-8\r\n";
-        return mail($this->getEmail(), $mailSubject, $mailMessage, $mailHeaders) ? "done" : "error";
+        $mailHeaders = array(
+            "To" => $this->getEmail(),
+            "From" => $this->yellow->system->get("sitename")." <".$this->yellow->system->get("email").">",
+            "Reply-To" => $comment["meta"]["name"]." <".$comment["meta"]["from"].">",
+            "Subject" => "[".$this->yellow->system->get("sitename")."] ".$this->yellow->page->get("title"),
+            "Date" => date(DATE_RFC2822),
+            "Mime-Version" => "1.0",
+            "Content-Type" => "text/plain; charset=utf-8",
+            "X-Request-Url" => $this->yellow->page->getUrl());
+        return $this->yellow->toolbox->mail("comment", $mailHeaders, $mailMessage) ? "done" : "error";
     }
 
     // Send notification email
@@ -384,11 +387,14 @@ class YellowComment {
         $mailMessage .= $this->yellow->page->getUrl() . "#" . $comment["meta"]["uid"] . "\r\n\r\n";
         $mailMessage .= "-- \r\n";
         $mailMessage .= $this->yellow->system->get("sitename") . "\r\n";
-        $mailSubject = mb_encode_mimeheader("[".$this->yellow->system->get("sitename")."] " . $this->yellow->page->get("title"));
-        $mailHeaders = "From: " . mb_encode_mimeheader($this->yellow->system->get("sitename")) . "<" . $this->yellow->system->get("email") . ">\r\n";
-        $mailHeaders .= "Mime-Version: 1.0\r\n";
-        $mailHeaders .= "Content-Type: text/plain; charset=utf-8\r\n";
-        return mail($comment["meta"]["from"], $mailSubject, $mailMessage, $mailHeaders) ? "done" : "error";
+        $mailHeaders = array(
+            "To" => $comment["meta"]["name"]." <".$comment["meta"]["from"].">",
+            "From" => $this->yellow->system->get("sitename")." <".$this->yellow->system->get("email").">",
+            "Subject" => "[".$this->yellow->system->get("sitename")."] ".$this->yellow->page->get("title"),
+            "Date" => date(DATE_RFC2822),
+            "Mime-Version" => "1.0",
+            "Content-Type" => "text/plain; charset=utf-8");
+        return $this->yellow->toolbox->mail("comment", $mailHeaders, $mailMessage) ? "done" : "error";
     }
 
     // Return number of visible comments

--- a/comment.php
+++ b/comment.php
@@ -312,7 +312,7 @@ class YellowComment {
 
     // Process user input
     function processSend() {
-        if ($this->yellow->isCommandLine()) $this->yellow->page->error(500, "Static website not supported!");
+        if ($this->yellow->lookup->isCommandLine()) $this->yellow->page->error(500, "Static website not supported!");
         $aid = $this->yellow->page->getRequest("aid");
         $action = $this->yellow->page->getRequest("action");
         if ($aid) {

--- a/extension.ini
+++ b/extension.ini
@@ -1,11 +1,11 @@
 # Datenstrom Yellow extension settings
 
 Extension: Comment
-Version: 0.8.18
+Version: 0.8.19
 Description: Simple commenting system.
 DocumentationUrl: https://github.com/GiovanniSalmeri/yellow-comment
 DownloadUrl: https://github.com/GiovanniSalmeri/yellow-comment/archive/main.zip
-Published: 2022-05-14 12:00:00
+Published: 2023-05-12 17:00:00
 Developer: Giovanni Salmeri
 Tag: feature
 system/extensions/comment.php: comment.php, create, update


### PR DESCRIPTION
To make this extension ready for alternative email transports. Some notes:

1. Renamed the "X-Contact-Url" header to "X-Request-Url", to stay in sync with other extensions
2. Removed the "X-Remote-Addr" header, which contained the user's IP address, this was removed in other extensions for privacy reasons (GDPR) a while ago and I removed it in this extension as well
3. Emails to moderators do currently not contain the recipient's full name, which may trigger spam filtering on some email clients, I didn't change it in this PR, maybe something for the future
4. Emails to users do currently expose the website's email address, in other extensions we use a configurable "noreply",  I didn't change it in this PR, maybe something for the future

Hope this helps.

